### PR TITLE
Program name fixed in the "Examples" help section

### DIFF
--- a/dsrepeater
+++ b/dsrepeater
@@ -3,6 +3,7 @@
 const pkg = require('./package.json');
 const prettyjson = require('prettyjson');
 const program = require('commander');
+const path = require('path');
 const CLI = require('clui');
 const inquirer = require('inquirer');
 const Preferences = require('preferences');
@@ -182,10 +183,11 @@ commands.map(command => command.split(' ')[0]).filter(utils.unique).forEach((com
 });
 
 program.on('--help', () => {
+  const programName = path.basename(process.argv[1], '.js');
   console.log('  Examples:');
   console.log('');
   commands.forEach((command) => {
-    console.log(`    $ ds-repeater ${command}`);
+    console.log(`    $ ${programName} ${command}`);
   });
   console.log('');
 });


### PR DESCRIPTION
The "Examples" section had 'ds-repeator' program name hardcoded, but actually it's not 'ds-repeater' but 'dsrepeater'.

Implemented program name extraction using a more universal method; this way it's compatible with what the commander library does.