### PR TITLE
Showing help information by default if no command specified

### DIFF
--- a/dsrepeater
+++ b/dsrepeater
@@ -192,6 +192,10 @@ program.on('--help', () => {
 
 program.parse(process.argv); // end with parse to parse through the input
 
+if (!process.argv.slice(2).length) {
+  program.help();
+}
+
 if (program.clear) {
   clearPreferences();
   console.log('Cleared preferences.');


### PR DESCRIPTION
It was quite misleading that if we run dsrepeater without any command, nothing happened. I would expect to see help information by default.